### PR TITLE
Fix React example and add public directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# React Hello World
+
+This repository contains a very small React example. The page is a single `index.html` file that loads React (and ReactDOM) from a CDN and renders "Hello, world!" on the screen.
+
+## Running Locally
+Simply open `index.html` in your browser to view the page. No build tools or bundlers are required.
+
+## Deploying to Netlify
+1. Push this repository to your Git provider (e.g., GitHub).
+2. In Netlify, choose **New site from Git** and select the repository.
+3. Set **build command** to `N/A` (there is no build step).
+4. Set **publish directory** to the root of the repo (`.`).
+5. Deploy the site.
+
+Netlify will host the static `index.html` file, and React will be loaded from a CDN.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>React Hello World</title>
+</head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+    <script>
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      const App = React.createElement('h1', null, 'Hello, world!');
+      root.render(App);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- simplify React example so it does not require Babel
- document the example in the README
- add an empty `public/` directory for assets

## Testing
- `npm test` *(fails: Could not read package.json)*