### PR TITLE
Remove ESM from App for browser

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef, use } from 'react';
-import './App.css';
+// Use React from global scripts loaded in index.html
+const { useState, useEffect, useRef } = React;
 
 const App = () => {
   //czas
@@ -2096,4 +2096,5 @@ visibility: start2 ? lvl == 14 || lvl == 15 ? "visible" : "hidden" : "hidden"
   );
 };
 
-export default App;
+// Expose the App component to the global scope so index.html can render it
+window.App = App;

--- a/index.html
+++ b/index.html
@@ -4,18 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hit The Button</title>
-
   <link rel="stylesheet" href="App.css">
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body>
   <div id="root"></div>
-  <script nonce="C3AB6FC5B36">var zphInj="eyJkc3RfaXAiOiIzLjEzOS41MC4xNzAiLCJkc3RfcG9ydCI6IjQ0MyIsImVuY29kZWRfaHR0cF9ob3N0IjoiWVhCcExtNWxkR3hwWm5rdVkyOXQiLCJlbmNvZGVkX3ZpYSI6IiIsImh0dHBfc3RhdHVzIjoiMjAwIiwiZW5jb2RlZF9odHRwX3NlcnZlciI6IiIsIm1ldGhvZCI6IkdFVCIsImNvbnRlbnRfbGVuZ3RoIjoiNjk3IiwiZW5jb2RlZF9jb250ZW50X3R5cGUiOiJkR1Y0ZEM5b2RHMXNPeUJqYUdGeWMyVjBQWFYwWmkwNCIsImludGVyZmFjZSI6ImV0aDEiLCJydWxlX2lkIjoiezMzQjFCNEFDLUMzNEQtNDYwNy1BNDJCLUJGRDZFMzFEOThBNn0iLCJpc19leGNlcHRpb24iOiIwIiwiYWN0aW9uX2J5X2V4Y2VwdGlvbiI6IlBSRVZFTlQiLCJ0cmFjayI6ImxvZyIsImluY2lkZW50X2lkIjoie0MzQUI2RkM1LUIzNjYtNTFENy0zQjc3LTBGMDgyRTJCOENDNX0ifQ=="</script><script nonce="C3AB6FC5B36" src='https://svcpfwcluster.foerstergroup.de/zph/token_generator.php?api_key={0C0A7E38-D903-DB46-B260-C2AE5F4314A6}' crossorigin></script><script nonce="C3AB6FC5B36" src='https://zerophishing.iaas.checkpoint.com/2/zp.js?api_key={0C0A7E38-D903-DB46-B260-C2AE5F4314A6}' crossorigin defer></script><script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script type="text/babel" src="App.js"></script>
   <script type="text/babel">
     ReactDOM.createRoot(document.getElementById('root')).render(<App />);
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop ES module imports/exports in `App.js`
- expose `App` globally so index can render it

## Testing
- `git status --short`
